### PR TITLE
Fixes caused by importing STARS benchmark as a test

### DIFF
--- a/benchmarks/apps/microbench-eor/microbench-eor.py
+++ b/benchmarks/apps/microbench-eor/microbench-eor.py
@@ -75,6 +75,7 @@ class MicrobenchEOR(ContainerTest):
         os.mkdir(os.path.join(self.outputdir, "outputs"))
         self.executable_opts = [
             "run",
+            "--no-home",
             "--bind", f"{self.data_dir}:/data",
             "--bind", f"{self.outputdir}:/project",
             os.path.join(self.code_dir, 'singularity_images/hera-pspec-mambaorg.sif'),

--- a/benchmarks/apps/microbench-multiwave/microbench-multiwave.py
+++ b/benchmarks/apps/microbench-multiwave/microbench-multiwave.py
@@ -85,6 +85,7 @@ class MicrobenchMULTIWAVE(ContainerTest):
         os.mkdir(os.path.join(self.outputdir, "logs"))
         self.executable_opts = [
             "exec",
+            "--no-home",
             "--bind",
             f"{self.data_dir}:{self.data_dir}",
             "--bind",

--- a/benchmarks/apps/microbench-multiwave/microbench-multiwave.py
+++ b/benchmarks/apps/microbench-multiwave/microbench-multiwave.py
@@ -85,6 +85,12 @@ class MicrobenchMULTIWAVE(ContainerTest):
         os.mkdir(os.path.join(self.outputdir, "logs"))
         self.executable_opts = [
             "exec",
+            "--bind",
+            f"{self.data_dir}:{self.data_dir}",
+            "--bind",
+            f"{self.outputdir}:{self.outputdir}",
+            "--bind",
+            f"{self.code_dir}:{self.code_dir}",
             os.path.join(self.code_dir, "singularity_images/pybdsf.sif"),
             f"bash",
             os.path.join(self.outputdir, "ssh_job.sh")

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -75,8 +75,7 @@ class STARScrossmatch(ContainerTest):
             os.path.join(self.outputdir, "ssh_job.sh")
         ]
 
-#    @sanity_function
-#    def validate(self):
-#        test_fits = fits.open(os.path.join(self.data_dir, "crossmatch_cat.fits"))
-#        return test_fits[1].data.shape[0] > 0
+    @sanity_function
+    def validate(self):
+        return True
 

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -72,7 +72,7 @@ class STARScrossmatch(ContainerTest):
             f"{self.outputdir}:/data",
             os.path.join(self.code_dir, "singularity_images/cross-matching.sif"),
             f"bash",
-            os.path.join(self.outputdir, "ssh_job.sh")
+            os.path.join("/data/ssh_job.sh")
         ]
 
     @sanity_function

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -9,6 +9,8 @@ from reframe.core.builtins import sanity_function, parameter, run_before, run_af
 
 from benchmarks.modules.utils import ContainerTest
 
+from astropy.io import fits
+
 @rfm.simple_test
 class STARScrossmatch(ContainerTest):
     bench_name="STARScrossmatch"
@@ -65,7 +67,16 @@ class STARScrossmatch(ContainerTest):
         os.mkdir(os.path.join(self.outputdir, "logs"))
         self.executable_opts = [
             "exec",
+            "--no-home",
+            "--bind",
+            f"{self.data_dir}:/data",
             os.path.join(self.code_dir, "singularity_images/cross-matching.sif"),
             f"bash",
             os.path.join(self.outputdir, "ssh_job.sh")
         ]
+
+    @sanity_function
+    def validate(self):
+        test_fits = fits.open(os.path.join(self.datadir, "crossmatch_cat.fits"))
+        return test_fits[1].data.shape[0] > 0
+

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -1,0 +1,70 @@
+import pathlib, os, subprocess, json
+
+from datetime import datetime as dt
+import reframe.utility.sanity as sn
+
+import reframe as rfm
+from reframe.core.backends import getlauncher
+from reframe.core.builtins import sanity_function, parameter, run_before, run_after, performance_function
+
+from benchmarks.modules.utils import ContainerTest
+
+@rfm.simple_test
+class STARScrossmatch(ContainerTest):
+    bench_name="STARScrossmatch"
+    valid_systems = ['*']
+    valid_prog_environs = ['default']
+    run_only_test = True
+
+    code_dir = ""
+    data_dir = ""
+
+    tasks = parameter([1])
+    num_tasks_per_node = 1
+    cpus_per_task = parameter([16])
+
+    executable = "singularity"
+
+    output_dict_list = []
+
+    @run_after('setup')
+    def copy_dirs_stage(self):
+        self.code_dir = os.path.join(self.stagedir, "STARS_crossmatch_Code")
+        os.makedirs(self.code_dir, exist_ok=True)
+        self.data_dir = os.path.join(self.stagedir, "STARS_crossmatch_Data")
+        os.makedirs(self.data_dir, exist_ok=True)
+
+    @run_after('setup')
+    def download_code(self):
+        if not os.path.isfile(os.path.join(self.code_dir, "singularity_images/cross-matching.sif")):
+            subprocess.run(
+                f"mkdir {os.path.join(self.code_dir, 'singularity_images')}",
+                shell=True
+            )
+            subprocess.run(
+                f"singularity pull registry.gitlab.com/ska-telescope/src/src-workloads/cross-matching {os.path.join(self.code_dir, 'singularity_images/cross-matching.sif')}",
+                shell=True)
+
+    @run_before('run')
+    def add_prerun_cmds(self):
+        self.prerun_cmds = [
+            f"touch {self.stagedir}/rfm_build.out",
+            f"touch {self.stagedir}/rfm_build.err",
+            f"touch {self.stagedir}/rfm_build.sh",
+            f"echo '#!/bin/bash' >> {self.outputdir}/ssh_job.sh",
+            f"echo '/scripts/run-task.sh' >> {self.outputdir}/ssh_job.sh",
+            f"echo \"Workflow start: $(date '+%Y-%m-%d %H:%M:%S')\" > {self.outputdir}/output.log"
+        ]
+        self.postrun_cmds = [
+            f"echo \"Workflow end: $(date '+%Y-%m-%d %H:%M:%S')\" >> {self.outputdir}/output.log"
+        ]
+
+    @run_before('run')
+    def set_executable_opts(self):
+        os.mkdir(os.path.join(self.outputdir, "logs"))
+        self.executable_opts = [
+            "exec",
+            os.path.join(self.code_dir, "singularity_images/cross-matching.sif"),
+            f"bash",
+            os.path.join(self.outputdir, "ssh_job.sh")
+        ]

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -75,8 +75,8 @@ class STARScrossmatch(ContainerTest):
             os.path.join(self.outputdir, "ssh_job.sh")
         ]
 
-    @sanity_function
-    def validate(self):
-        test_fits = fits.open(os.path.join(self.data_dir, "crossmatch_cat.fits"))
-        return test_fits[1].data.shape[0] > 0
+#    @sanity_function
+#    def validate(self):
+#        test_fits = fits.open(os.path.join(self.data_dir, "crossmatch_cat.fits"))
+#        return test_fits[1].data.shape[0] > 0
 

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -44,7 +44,7 @@ class STARScrossmatch(ContainerTest):
             subprocess.run(
                 f"singularity pull docker://registry.gitlab.com/ska-telescope/src/src-workloads/cross-matching",
                 shell=True)
-            subprocess.run(f"mv cross-match_latest.sif {os.path.join(self.code_dir, 'singularity_images/cross-matching.sif')}", shell=True)
+            subprocess.run(f"mv cross-matching_latest.sif {os.path.join(self.code_dir, 'singularity_images/cross-matching.sif')}", shell=True)
 
     @run_before('run')
     def add_prerun_cmds(self):

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -42,8 +42,9 @@ class STARScrossmatch(ContainerTest):
                 shell=True
             )
             subprocess.run(
-                f"singularity pull docker://registry.gitlab.com/ska-telescope/src/src-workloads/cross-matching {os.path.join(self.code_dir, 'singularity_images/cross-matching.sif')}",
+                f"singularity pull docker://registry.gitlab.com/ska-telescope/src/src-workloads/cross-matching",
                 shell=True)
+            subprocess.run(f"mv cross-match.sif singularity_images/cross-matching.sif", shell=True)
 
     @run_before('run')
     def add_prerun_cmds(self):

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -42,7 +42,7 @@ class STARScrossmatch(ContainerTest):
                 shell=True
             )
             subprocess.run(
-                f"singularity pull registry.gitlab.com/ska-telescope/src/src-workloads/cross-matching {os.path.join(self.code_dir, 'singularity_images/cross-matching.sif')}",
+                f"singularity pull docker://registry.gitlab.com/ska-telescope/src/src-workloads/cross-matching {os.path.join(self.code_dir, 'singularity_images/cross-matching.sif')}",
                 shell=True)
 
     @run_before('run')

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -77,6 +77,6 @@ class STARScrossmatch(ContainerTest):
 
     @sanity_function
     def validate(self):
-        test_fits = fits.open(os.path.join(self.datadir, "crossmatch_cat.fits"))
+        test_fits = fits.open(os.path.join(self.data_dir, "crossmatch_cat.fits"))
         return test_fits[1].data.shape[0] > 0
 

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -55,7 +55,7 @@ class STARScrossmatch(ContainerTest):
             f"touch {self.stagedir}/rfm_build.err",
             f"touch {self.stagedir}/rfm_build.sh",
             f"echo '#!/bin/bash' >> {self.outputdir}/ssh_job.sh",
-            f"echo '/scripts/run-task.sh' >> {self.data_dir}/ssh_job.sh",
+            f"echo '/scripts/run-task.sh' >> {self.outputdir}/ssh_job.sh",
             f"echo \"Workflow start: $(date '+%Y-%m-%d %H:%M:%S')\" > {self.outputdir}/output.log"
         ]
         self.postrun_cmds = [

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -27,8 +27,6 @@ class STARScrossmatch(ContainerTest):
 
     output_dict_list = []
 
-    profiler = False
-
     @run_after('setup')
     def copy_dirs_stage(self):
         self.code_dir = os.path.join(self.stagedir, "STARS_crossmatch_Code")

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -55,7 +55,7 @@ class STARScrossmatch(ContainerTest):
             f"touch {self.stagedir}/rfm_build.err",
             f"touch {self.stagedir}/rfm_build.sh",
             f"echo '#!/bin/bash' >> {self.outputdir}/ssh_job.sh",
-            f"echo '/scripts/run-task.sh' >> {self.outputdir}/ssh_job.sh",
+            f"echo '/scripts/run-task.sh' >> {self.data_dir}/ssh_job.sh",
             f"echo \"Workflow start: $(date '+%Y-%m-%d %H:%M:%S')\" > {self.outputdir}/output.log"
         ]
         self.postrun_cmds = [
@@ -69,7 +69,7 @@ class STARScrossmatch(ContainerTest):
             "exec",
             "--no-home",
             "--bind",
-            f"{self.data_dir}:/data",
+            f"{self.outputdir}:/data",
             os.path.join(self.code_dir, "singularity_images/cross-matching.sif"),
             f"bash",
             os.path.join(self.outputdir, "ssh_job.sh")
@@ -77,5 +77,5 @@ class STARScrossmatch(ContainerTest):
 
     @sanity_function
     def validate(self):
-        return True
-
+        test_fits = fits.open(os.path.join(self.outputdir, "crossmatch_cat.fits"))
+        return test_fits[1].data.shape[0] > 0

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -27,6 +27,8 @@ class STARScrossmatch(ContainerTest):
 
     output_dict_list = []
 
+    profiler = False
+
     @run_after('setup')
     def copy_dirs_stage(self):
         self.code_dir = os.path.join(self.stagedir, "STARS_crossmatch_Code")

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -44,7 +44,7 @@ class STARScrossmatch(ContainerTest):
             subprocess.run(
                 f"singularity pull docker://registry.gitlab.com/ska-telescope/src/src-workloads/cross-matching",
                 shell=True)
-            subprocess.run(f"mv cross-match.sif {os.path.join(self.code_dir, 'singularity_images/cross-matching.sif')}", shell=True)
+            subprocess.run(f"mv cross-match_latest.sif {os.path.join(self.code_dir, 'singularity_images/cross-matching.sif')}", shell=True)
 
     @run_before('run')
     def add_prerun_cmds(self):

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -44,7 +44,7 @@ class STARScrossmatch(ContainerTest):
             subprocess.run(
                 f"singularity pull docker://registry.gitlab.com/ska-telescope/src/src-workloads/cross-matching",
                 shell=True)
-            subprocess.run(f"mv cross-match.sif singularity_images/cross-matching.sif", shell=True)
+            subprocess.run(f"mv cross-match.sif {os.path.join(self.code_dir, 'singularity_images/cross-matching.sif'))}", shell=True)
 
     @run_before('run')
     def add_prerun_cmds(self):

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -44,7 +44,7 @@ class STARScrossmatch(ContainerTest):
             subprocess.run(
                 f"singularity pull docker://registry.gitlab.com/ska-telescope/src/src-workloads/cross-matching",
                 shell=True)
-            subprocess.run(f"mv cross-match.sif {os.path.join(self.code_dir, 'singularity_images/cross-matching.sif'))}", shell=True)
+            subprocess.run(f"mv cross-match.sif {os.path.join(self.code_dir, 'singularity_images/cross-matching.sif')}", shell=True)
 
     @run_before('run')
     def add_prerun_cmds(self):

--- a/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
+++ b/benchmarks/apps/stars-cross-matching/stars-cross-matching.py
@@ -79,3 +79,38 @@ class STARScrossmatch(ContainerTest):
     def validate(self):
         test_fits = fits.open(os.path.join(self.outputdir, "crossmatch_cat.fits"))
         return test_fits[1].data.shape[0] > 0
+
+    @run_before("performance")
+    def output_list_dict(self):
+        """
+        In order to use the database handler perflog 'swiftdb', self.output_dict_list must be defined.
+        This dictionary should include at least:
+        - TimeOfTest [str]
+        - SystemPartition [str]
+        - <Desired Output variables> [Format Determined by entry]
+        """
+        start_str = sn.evaluate(sn.extractsingle(
+            r'Workflow start: (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})',
+            pathlib.Path(self.outputdir) / pathlib.Path("output.log"),
+            tag=1
+        ))
+        finish_str = sn.evaluate(sn.extractsingle(
+            r'Workflow end: (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})',
+            pathlib.Path(self.outputdir) / pathlib.Path("output.log"),
+            tag=1
+        ))
+        start = dt.strptime(start_str, "%Y-%m-%d %H:%M:%S")
+        finish = dt.strptime(finish_str, "%Y-%m-%d %H:%M:%S")
+
+        elapsed_seconds = (finish - start).total_seconds()
+
+        time_of_test = str(dt.now().strftime("%Y-%m-%d %H:%M:%S"))
+
+        self.output_dict_list += [
+            {
+                "TimeOfTest": time_of_test,
+                "SystemPartition": f"{os.environ.get('GH_RUNNER')} - {self.current_system.name} - {self.current_partition.name}",
+                "ExecutionTime": elapsed_seconds
+            }
+        ]
+        print(self.output_dict_list)

--- a/benchmarks/modules/utils.py
+++ b/benchmarks/modules/utils.py
@@ -293,7 +293,7 @@ class ContainerTest(rfm.RegressionTest, special=True):
 
     @run_before('compile')
     def add_profiler(self):
-        if hasattr(self, profiler):
+        if hasattr(self, 'profiler'):
             # Command to use to view profiling traces
             viewer_cmd = None
             # Arguments to pass to the viewer

--- a/benchmarks/modules/utils.py
+++ b/benchmarks/modules/utils.py
@@ -293,7 +293,7 @@ class ContainerTest(rfm.RegressionTest, special=True):
 
     @run_before('compile')
     def add_profiler(self):
-        if self.profiler:
+        if hasattr(self, profiler):
             # Command to use to view profiling traces
             viewer_cmd = None
             # Arguments to pass to the viewer


### PR DESCRIPTION
I thought it would be a good idea to pull in one of the STARS benchmarks as a test to see how easy it was.

At random I picked https://gitlab.com/ska-telescope/src/src-workloads/-/tree/master/tasks/cross-matching?ref_type=heads

In doing so I discovered that we broke container benchmarks when profiling was added so I fixed that.

I also changed the behaviour in EOR and MULTIWAVE so that they don't mount the entire user's home directory which moderately improves security. It's more challenging in LOFARINT because of CWL.